### PR TITLE
ci: Ensure the arguments are passed to the changes release command

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -160,5 +160,5 @@ popd
 
 # Attempt to create a version tag and publish a GitHub release; fails quietly if there's no new release.
 if $RELEASE || $TRY_RELEASE ; then
-    "$CHANGES_SCRIPT" --scope macOS release --skip-if-empty --push --command "\"${CHANGES_GITHUB_RELEASE_SCRIPT}\" \"$@\"" "${BUILD_DIRECTORY}/${ZIP_BASENAME}"
+    "$CHANGES_SCRIPT" --scope macOS release --skip-if-empty --push --command "\"${CHANGES_GITHUB_RELEASE_SCRIPT}\" \"\$@\"" "${BUILD_DIRECTORY}/${ZIP_BASENAME}"
 fi


### PR DESCRIPTION
This change also catches up to the latest version of the changes script with a fix for legacy scopes.